### PR TITLE
Added encoding = 'utf-8' for compatibility with windows

### DIFF
--- a/manga109api/manga109api.py
+++ b/manga109api/manga109api.py
@@ -18,13 +18,13 @@ class Parser(object):
         self.books = []  # book titles
         self.annotations = {}  # annotation in the form of dict
 
-        with (self.root_dir / "books.txt").open("rt") as f:
+        with (self.root_dir / "books.txt").open("rt", encoding= 'utf-8') as f:
             self.books = [line.rstrip() for line in f]
 
         for book in self.books:
             if book_titles != "all" and book not in book_titles:
                 continue
-            with (self.root_dir / "annotations" / (book + ".xml")).open("rt") as f:
+            with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
                 annotation = xmltodict.parse(f.read())
             annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
             _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes


### PR DESCRIPTION
This is just a small change to support windows users, since the default encoding used by windows when using the open file function is not UTF-8. This throws an error when using the parser function in windows.

This is easily solved just by specifying the correct encoding when calling the open file function.