### PR TITLE
:bug: Modify the bug in an example of visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ def draw_rectangle(img, x0, y0, x1, y1, annotation_type):
 img = Image.open(p.img_path(book="ARMS", index=6))
 for annotation_type in ["body", "face", "frame", "text"]:
     rois = p.annotations["ARMS"]["book"]["pages"]["page"][6][annotation_type]
+    if type(rois) is dict:
+        rois = [rois]
     for roi in rois:
         draw_rectangle(img, roi["@xmin"], roi["@ymin"], roi["@xmax"], roi["@ymax"], annotation_type)
 


### PR DESCRIPTION
I got an error in an example of visualization.
That's because of data that only has a single element.　(e.g. ARMS, index=2)
I think the reason for this is that if there is more than one element, the list comes back, but if there is one, the dict comes back.

So, The type of the return value is now checked before drawing.