### PR TITLE
一冊ずつアノテーションを取得する処理の追加

### DIFF
--- a/manga109api/manga109api.py
+++ b/manga109api/manga109api.py
@@ -16,19 +16,25 @@ class Parser(object):
         """
         self.root_dir = pathlib.Path(root_dir)
         self.books = []  # book titles
-        self.annotations = {}  # annotation in the form of dict
 
-        with (self.root_dir / "books.txt").open("rt", encoding= 'utf-8') as f:
+        with (self.root_dir / "books.txt").open("rt", encoding='utf-8') as f:
             self.books = [line.rstrip() for line in f]
 
-        for book in self.books:
-            if book_titles != "all" and book not in book_titles:
-                continue
-            with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
-                annotation = xmltodict.parse(f.read())
-            annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
-            _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
-            self.annotations[book] = annotation
+    def get_annotation(self, book):
+        """
+        タイトルを引数にアノテーションを返す
+
+        Args:
+            book (str): 漫画のタイトル
+
+        Returns:
+            dict: 漫画のアノテーション 
+        """
+        with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding='utf-8') as f:
+            annotation = xmltodict.parse(f.read())
+        annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
+        _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
+        return annotation
 
     def img_path(self, book, index):
         """


### PR DESCRIPTION
## 変更点

以下の3つの変更を加えた

- `get_annotation(book)`関数によって対象漫画のアノテーションを追加
- アノテーションの各要素をtitle・character・pageのキーで取得できるようにシンプルにした
- 各ページのアノテーション情報の形式が常に一致するように変更

これにより、インスタンス作成時のロードを短縮するとともに、アノテーションの形状が一致しない場合の余計なif文を書く必要をなくした。