### PR TITLE
Add: get_annotation method

### DIFF
--- a/manga109api/manga109api.py
+++ b/manga109api/manga109api.py
@@ -4,31 +4,34 @@ import xmltodict
 
 
 class Parser(object):
-    def __init__(self, root_dir, book_titles="all"):
+    def __init__(self, root_dir):
         """
         Manga109 annotation parser
 
         Args:
             root_dir (str): The path of the root directory of Manga109 data, e.g., 'YOUR_PATH/Manga109_2017_09_28'
-            book_titles (str or list): The book titles to be parsed.
-                For example, if book_titles = ["ARMS", "AisazuNihaIrarenai"], these two books are read.
-                The default value is "all", where all books are read
         """
         self.root_dir = pathlib.Path(root_dir)
         self.books = []  # book titles
-        self.annotations = {}  # annotation in the form of dict
 
         with (self.root_dir / "books.txt").open("rt", encoding= 'utf-8') as f:
             self.books = [line.rstrip() for line in f]
 
-        for book in self.books:
-            if book_titles != "all" and book not in book_titles:
-                continue
-            with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
-                annotation = xmltodict.parse(f.read())
-            annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
-            _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
-            self.annotations[book] = annotation
+    def get_annotation(self, book):
+        """
+        Given a book title, return annotation in the form of dict
+
+        Args:
+            book (str): A title of a book. Should be in self.books.
+
+        Returns:
+            annotation (dict): 
+        """
+        with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
+            annotation = xmltodict.parse(f.read())
+        annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
+        _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
+        return annotation
 
     def img_path(self, book, index):
         """


### PR DESCRIPTION
There are three changes.

- `get_annotation(title)` method gets the annotation of a comic.
- Reduce the deep nesting of annotations.
  - `['book']['@title']` -> `['title']`
  - `['book']['characters']['character']` -> `['character']`
  - `['book']['pages']['page']` -> `['page']`
- `body`, `face`, `frame`, `text` annotations are always in the form of list.

**Before**
```python
pprint(p.annotations["ARMS"]["book"]["pages"]["page"][67])
# {'@height': 1170,
#  '@index': 67,
#  '@width': 1654,
#  'frame': [{'@id': '000007c5',
#             '@xmax': 1568,
#             '@xmin': 909,
#             '@ymax': 1093,
#             '@ymin': 97},
#            {'@id': '000007c6',
#             '@xmax': 744,
#             '@xmin': 78,
#             '@ymax': 1095,
#             '@ymin': 95}],
#  'text': {'#text': '天に軍を....',
#           '@id': '000007c7',
#           '@xmax': 1265,
#           '@xmin': 1241,
#           '@ymax': 240,
#           '@ymin': 120}}
```

**After**
```python
annotation = p.get_annotation("ARMS")
pprint(annotation['page'][67])
# {'@height': 1170,
#  '@index': 67,
#  '@width': 1654,
#  'body': [],
#  'face': [],
#  'frame': [{'@id': '000007c5',
#             '@xmax': 1568,
#             '@xmin': 909,
#             '@ymax': 1093,
#             '@ymin': 97},
#            {'@id': '000007c6',
#             '@xmax': 744,
#             '@xmin': 78,
#             '@ymax': 1095,
#             '@ymin': 95}],
#  'text': [{'#text': '天に軍を....',
#            '@id': '000007c7',
#            '@xmax': 1265,
#            '@xmin': 1241,
#            '@ymax': 240,
#            '@ymin': 120}]}
```

Notes:
This PR does not include README and version(0.1.2) changes.
