### PR TITLE
v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package provides a simple Python API to read annotation data (i.e., parsing
 with some utility functions such as reading an image.
 
 ## News
+- [Oct 6, 2020]: v0.3.0 is now available. We added [a tag-order-preserving option](https://github.com/manga109/manga109api/blob/master/manga109api/manga109api.py#L31) for `get_annotation`. See (4) in [the Example section](https://github.com/manga109/manga109api#example) for instructions.
 - [Aug 28, 2020]: v0.2.0 is out. [The API is drastically improved](https://github.com/matsui528/manga109api/pull/8), thanks for [@i3ear](https://github.com/i3ear)!
 - [Aug 28, 2020]: The repository is moved to [manga109 organization](https://github.com/manga109)
 

--- a/manga109api/__init__.py
+++ b/manga109api/__init__.py
@@ -1,2 +1,3 @@
 __all__ = ['Parser']
+__version__ = '0.3.0'
 from .manga109api import Parser

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import re
 
 with open('README.md') as f:
     readme = f.read()
@@ -8,9 +9,15 @@ with open('requirements.txt') as f:
     for line in f:
         requirements.append(line.rstrip())
 
+with open('manga109api/__init__.py') as f:
+    # Version is written in manga109api/__init__.py
+    # This function simply reads it
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
+
+
 setup(
     name='manga109api',
-    version='0.2.1',
+    version=version,
     description='Simple python API to read annotation data of Manga109',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v0.3.0 includes:

https://github.com/manga109/manga109api/pull/17
- Added a tag-order-preserving option for get_annotation
- Refactored the large part of the code.

https://github.com/manga109/manga109api/pull/18
- Fixed a small error at test code

This PR:
- Move the version description from `setup.py` to `manga109api/__init__.py`
- Now we can check the version easily: `import manga109api`, `print(manga109api.__version__)`