### PR TITLE
add try & except for custom tag

### DIFF
--- a/manga109api/manga109api.py
+++ b/manga109api/manga109api.py
@@ -18,7 +18,6 @@ class Parser(object):
         with (self.root_dir / "books.txt").open("rt", encoding='utf-8') as f:
             self.books = [line.rstrip() for line in f]
 
-
     def get_annotation(self, book, annotation_type="annotations", separate_by_tag=True):
         """
         Given a book title, return its annotations as a dict.
@@ -62,15 +61,18 @@ class Parser(object):
                 input:  {"index": "5", "title": "a"}
                 output: {"@index": 5,  "@title": "a"}
             """
-            return dict([("@"+k, int_literals_to_int(v)) for k, v in d.items()])
+            return dict([("@" + k, int_literals_to_int(v)) for k, v in d.items()])
 
         with (self.root_dir / annotation_type / (book + ".xml")).open("rt", encoding='utf-8') as f:
             xml = ET.parse(f).getroot()
-        annotation = {"title" : xml.attrib["title"]}
+        annotation = {"title": xml.attrib["title"]}
 
         characters = []
-        for t in xml.find("characters"):
-            characters.append(formatted_dict(t.attrib))
+        try:
+            for t in xml.find("characters"):
+                characters.append(formatted_dict(t.attrib))
+        except:
+            pass
         annotation["character"] = characters
 
         pages = []
@@ -90,7 +92,10 @@ class Parser(object):
                 d["type"] = bb_xml.tag
 
                 if separate_by_tag:
-                    page[bb_xml.tag].append(d)
+                    try:
+                        page[bb_xml.tag].append(d)
+                    except:
+                        page[bb_xml.tag] = [d]
                 else:
                     page["contents"].append(d)
 

--- a/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
+++ b/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
@@ -2,10 +2,10 @@
   <pages>
     <page index="0" width="1654" height="1170">
       <body id="00000018" xmin="848" ymin="236" xmax="985" ymax="614" character="00000017"/>
-      <custom_tag id="00000019" attr_num="0" attr_str="aaa" attr_mix="123a" character="00000017"/>
-      <custom_tag id="00000020" attr_num="12" attr_str="bbb" attr_mix="456b" character="00000017"/>
-      <custom_tag2 id="00000021" attr_num="345" attr_str="ccc" attr_mix="7cd" character="00000018">dummy_text</custom_tag2>
-      <custom_tag2 id="00000022" attr_num="6789" attr_str="ddd" attr_mix="8ef" character="00000018">dummy_text2</custom_tag2>
+      <custom_tag id="00000019" attr_num="0" attr_str="aaa" attr_mix="123a" attr_unk='111' character="00000017"/>
+      <custom_tag id="00000020" attr_num="12" attr_str="bbb" attr_mix="456b" attr_unk='asdf' character="00000017"/>
+      <custom_tag2 id="00000021" attr_num="345" attr_str="ccc" attr_mix="7cd" attr_unk='1a' attr_unk2='2b' character="00000018">dummy_text</custom_tag2>
+      <custom_tag2 id="00000022" attr_num="6789" attr_str="ddd" attr_mix="8ef" attr_unk='b' attr_unk2='33' character="00000018">dummy_text2</custom_tag2>
     </page>
     <page index="1" width="1654" height="1170"/>
     <page index="2" width="1654" height="1170"/>

--- a/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
+++ b/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
@@ -1,4 +1,8 @@
 <book title="TitleC">
+  <characters>
+    <character id="00000017" name="山田太郎"/>
+    <character id="00000018" name="田中花子"/>
+  </characters>
   <pages>
     <page index="0" width="1654" height="1170">
       <body id="00000018" xmin="848" ymin="236" xmax="985" ymax="614" character="00000017"/>

--- a/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
+++ b/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
@@ -6,10 +6,13 @@
   <pages>
     <page index="0" width="1654" height="1170">
       <body id="00000018" xmin="848" ymin="236" xmax="985" ymax="614" character="00000017"/>
+      <!-- w/ character -->
       <custom_tag id="00000019" attr_num="0" attr_str="aaa" attr_mix="123a" attr_unk='111' character="00000017"/>
       <custom_tag id="00000020" attr_num="12" attr_str="bbb" attr_mix="456b" attr_unk='asdf' character="00000017"/>
       <custom_tag2 id="00000021" attr_num="345" attr_str="ccc" attr_mix="7cd" attr_unk='1a' attr_unk2='2b' character="00000018">dummy_text</custom_tag2>
       <custom_tag2 id="00000022" attr_num="6789" attr_str="ddd" attr_mix="8ef" attr_unk='b' attr_unk2='33' character="00000018">dummy_text2</custom_tag2>
+      <!-- w/o character -->
+      <custom_tag3 id="00000023" attr_num="234" attr_str="xxx" attr_mix="12fsd3a" attr_unk='13411'/>
     </page>
     <page index="1" width="1654" height="1170"/>
     <page index="2" width="1654" height="1170"/>

--- a/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
+++ b/tests/data_dummy/annotations/TitleC_with_custom_tag.xml
@@ -1,0 +1,13 @@
+<book title="TitleC">
+  <pages>
+    <page index="0" width="1654" height="1170">
+      <body id="00000018" xmin="848" ymin="236" xmax="985" ymax="614" character="00000017"/>
+      <custom_tag id="00000019" attr_num="0" attr_str="aaa" attr_mix="123a" character="00000017"/>
+      <custom_tag id="00000020" attr_num="12" attr_str="bbb" attr_mix="456b" character="00000017"/>
+      <custom_tag2 id="00000021" attr_num="345" attr_str="ccc" attr_mix="7cd" character="00000018">dummy_text</custom_tag2>
+      <custom_tag2 id="00000022" attr_num="6789" attr_str="ddd" attr_mix="8ef" character="00000018">dummy_text2</custom_tag2>
+    </page>
+    <page index="1" width="1654" height="1170"/>
+    <page index="2" width="1654" height="1170"/>
+  </pages>
+</book>

--- a/tests/data_dummy/books.txt
+++ b/tests/data_dummy/books.txt
@@ -1,2 +1,3 @@
 TitleA
 TitleB
+TitleC_with_custom_tag

--- a/tests/test_data_type.py
+++ b/tests/test_data_type.py
@@ -39,9 +39,8 @@ def test_data_type():
 
                 else:
                     assert isinstance(obj["@id"], str)
-                    assert isinstance(obj["@attr_num"], int)
-                    assert isinstance(obj["@attr_str"], str)
-                    assert isinstance(obj["@attr_mix"], str)
+                    for key in obj.keys():
+                        assert isinstance(obj[key], (int, str))
 
                     if "#text" in obj.keys():
                         assert isinstance(obj["#text"], str)
@@ -87,9 +86,8 @@ def test_data_type_separated():
                 elif obj_type not in {"@index", "@width", "@height"}:
                     for obj in page[obj_type]:
                         assert isinstance(obj["@id"], str)
-                        assert isinstance(obj["@attr_num"], int)
-                        assert isinstance(obj["@attr_str"], str)
-                        assert isinstance(obj["@attr_mix"], str)
-
+                        for key in obj.keys():
+                            assert isinstance(obj[key], (int, str))
+                        
                         if "#text" in obj.keys():
                             assert isinstance(obj["#text"], str)

--- a/tests/test_data_type.py
+++ b/tests/test_data_type.py
@@ -26,15 +26,26 @@ def test_data_type():
 
             assert isinstance(page["contents"], list)
             for obj in page["contents"]:
-                assert isinstance(obj["@id"], str)
-                assert isinstance(obj["@xmin"], int)
-                assert isinstance(obj["@xmax"], int)
-                assert isinstance(obj["@ymin"], int)
-                assert isinstance(obj["@ymax"], int)
-                assert isinstance(obj["type"], str)
+                if obj["type"] in {"body", "face", "frame", "text"}:
+                    assert isinstance(obj["@id"], str)
+                    assert isinstance(obj["@xmin"], int)
+                    assert isinstance(obj["@xmax"], int)
+                    assert isinstance(obj["@ymin"], int)
+                    assert isinstance(obj["@ymax"], int)
+                    assert isinstance(obj["type"], str)
 
-                if obj["type"] == "text":
-                    assert isinstance(obj["#text"], str)
+                    if obj["type"] == "text":
+                        assert isinstance(obj["#text"], str)
+
+                else:
+                    assert isinstance(obj["@id"], str)
+                    assert isinstance(obj["@attr_num"], int)
+                    assert isinstance(obj["@attr_str"], str)
+                    assert isinstance(obj["@attr_mix"], str)
+
+                    if "#text" in obj.keys():
+                        assert isinstance(obj["#text"], str)
+
 
 def test_data_type_separated():
     manga109_root_dir = "tests/data_dummy/"
@@ -59,15 +70,26 @@ def test_data_type_separated():
             assert isinstance(page["@width"], int)
             assert isinstance(page["@height"], int)
 
-            for obj_type in {"body", "face", "frame", "text"}:
-                assert isinstance(page[obj_type], list)
-                for obj in page[obj_type]:
-                    assert isinstance(obj["@id"], str)
-                    assert isinstance(obj["@xmin"], int)
-                    assert isinstance(obj["@xmax"], int)
-                    assert isinstance(obj["@ymin"], int)
-                    assert isinstance(obj["@ymax"], int)
-                    assert obj["type"] == obj_type
+            for obj_type in page.keys():
+                if obj_type in {"body", "face", "frame", "text"}:
+                    assert isinstance(page[obj_type], list)
+                    for obj in page[obj_type]:
+                        assert isinstance(obj["@id"], str)
+                        assert isinstance(obj["@xmin"], int)
+                        assert isinstance(obj["@xmax"], int)
+                        assert isinstance(obj["@ymin"], int)
+                        assert isinstance(obj["@ymax"], int)
+                        assert obj["type"] == obj_type
 
-                    if obj_type == "text":
-                        assert isinstance(obj["#text"], str)
+                        if obj_type == "text":
+                            assert isinstance(obj["#text"], str)
+
+                elif obj_type not in {"@index", "@width", "@height"}:
+                    for obj in page[obj_type]:
+                        assert isinstance(obj["@id"], str)
+                        assert isinstance(obj["@attr_num"], int)
+                        assert isinstance(obj["@attr_str"], str)
+                        assert isinstance(obj["@attr_mix"], str)
+
+                        if "#text" in obj.keys():
+                            assert isinstance(obj["#text"], str)

--- a/tests/test_data_type.py
+++ b/tests/test_data_type.py
@@ -37,9 +37,15 @@ def test_data_type():
                     if obj["type"] == "text":
                         assert isinstance(obj["#text"], str)
 
+                # custom tag test
                 else:
                     assert isinstance(obj["@id"], str)
-                    for key in obj.keys():
+                    assert isinstance(obj["@attr_num"], int)
+                    assert isinstance(obj["@attr_str"], str)
+                    assert isinstance(obj["@attr_mix"], str)
+                    assert isinstance(obj["type"], str)
+
+                    for key in (obj.keys() - {"@id", "@attr_num", "@attr_str", "@attr_mix", "type"}):
                         assert isinstance(obj[key], (int, str))
 
                     if "#text" in obj.keys():
@@ -83,10 +89,16 @@ def test_data_type_separated():
                         if obj_type == "text":
                             assert isinstance(obj["#text"], str)
 
+                # custom tag test
                 elif obj_type not in {"@index", "@width", "@height"}:
                     for obj in page[obj_type]:
                         assert isinstance(obj["@id"], str)
-                        for key in obj.keys():
+                        assert isinstance(obj["@attr_num"], int)
+                        assert isinstance(obj["@attr_str"], str)
+                        assert isinstance(obj["@attr_mix"], str)
+                        assert obj["type"] == obj_type
+                        
+                        for key in (obj.keys() - {"@id", "@attr_num", "@attr_str", "@attr_mix", "type"}):
                             assert isinstance(obj[key], (int, str))
                         
                         if "#text" in obj.keys():


### PR DESCRIPTION
Currently, we can only use predefined tags `annotation_tags = ["frame", "face", "body", "text"]`.

In this PR, by adding try & except, we can handle custom tags.